### PR TITLE
Modify query to get Prefect details of the mentor

### DIFF
--- a/server/schema/schema.js
+++ b/server/schema/schema.js
@@ -52,6 +52,12 @@ const MentorType = new GraphQLObjectType({
     contact: { type: GraphQLString },
     email: { type: GraphQLString },
     prefect: { type: GraphQLID },
+    prefectDetails: {
+      type: PrefectType,
+      resolve(parent, args) {
+        return Prefect.findById(parent.prefect);
+      },
+    },
     mentees: {
       type: new GraphQLList(MenteeType),
       resolve(parent, args) {


### PR DESCRIPTION
Issue No. :- #6 
An additional query property called prefectDetails has been added which will give the prefect details of the mentor who is being queried.